### PR TITLE
Allow base URL to be configurable

### DIFF
--- a/lib/outbound.rb
+++ b/lib/outbound.rb
@@ -31,9 +31,9 @@ module Outbound
     }.freeze
   end
 
-  def self.init(api_key, log_level = Logger::ERROR)
+  def self.init(api_key, log_level = Logger::ERROR, base_url: BASE_URL)
     @logger.level = log_level
-    @ob = Outbound::Client.new api_key, @logger
+    @ob = Outbound::Client.new api_key, @logger, base_url: base_url
   end
 
   def self.alias(user_id, previous_id)
@@ -155,9 +155,10 @@ module Outbound
   class Client
     include Defaults
 
-    def initialize(api_key, logger)
+    def initialize(api_key, logger, base_url: base_url)
       @api_key = api_key
       @logger = logger
+      @base_url = base_url
     end
 
     def alias(user_id, previous_id)


### PR DESCRIPTION
📤
cc/ @outboundio/engineering  @mugdhachauhan @Fernando-Liu-Zendesk   

## Description

To make it easier to test outbound in multiple environments, we need to allow overriding of the Outbound base URL.

```ruby
Outbound.init("Your Private API KEY", base_url: 'https://api.someplace.com/v2')
```

## Not in scope

- Adding this to the public API documentation, as this is primarily for internal use.
- Updating tests (they need some love separately)

## Risks

- Low: non-breaking change - doesn't break existing interface
- Medium: Could break compatibility with clients using Ruby < 2.0.0 as it uses keyword parameters. Ruby 2.0.0 is was released over 4 years ago, so this shouldn't be a big problem. 